### PR TITLE
Fix html form to have a proper structure

### DIFF
--- a/app/views/carts/_modal.html.haml
+++ b/app/views/carts/_modal.html.haml
@@ -8,15 +8,15 @@
 
       .modal-body
 
-        %form
+        = form_tag order_cart_path do
 
           .form-group
             = label_tag 'Email'
-            %input.form-control{placeholder: 'email', type: 'email', name: 'user_email'}
+            = email_field 'user_email', nil, placeholder: 'Email address', type: :email, class: 'form-control'
 
           .form-group
             = label_tag 'Add your comment:'
-            %input.form-control{placeholder: 'comment', type: 'text', name: 'comment'}
+            = text_field 'comment', nil, class: 'form-control', placeholder: 'comment', type: 'text'
 
-          = link_to 'Order', order_cart_path, method: :post, class: 'btn btn-primary'
+          = submit_tag 'Order', class: 'btn btn-primary'
 


### PR DESCRIPTION
Проблема була в передачі параметрів. Ти використав хелпер `link_to` він призначенний для відображення посилань, тобто тегів '<a></a>'. Коли натискати на цей тег відбувається GET-запит. Але цей хелпер, що ти використав розумніший, він вміє будувати форму, якщо йому вказати тип запиту POST. Відповідно він і будував тобі форму але твої інпути з параметрами були поза межами форми і не приходили на сервер при натисканні кнопки. Я переробив це на явно визначену форму.
Ось деталі в документації:
http://apidock.com/rails/v3.2.8/ActionView/Helpers/UrlHelper/link_to